### PR TITLE
Firefox Android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ ArchLinux manual pages                 | `alman`    | [AMO][arch-man]
 * Install dependencies:
   * `npm i`
 * Lint (check for manifest syntax errors)
-  * `npm run lint -- -s web-extensions/<ext-name>`
+  * `npm run lint -- -s web-extensions/v3/<ext-name>`
 * Run add-on in isolated Firefox instance using [web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext) (open the [Browser Toolbox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox) for console logging):
-  * `npm run run -- -s web-extensions/<ext-name>`
+  * `npm run run -- -s web-extensions/v3/<ext-name>`
 * Package for distribution:
-  * One extension: `npm run build -- -s web-extensions/<ext-name>`
+  * One extension: `npm run build -- -s web-extensions/v3/<ext-name>`
   * All extensions: `npm run buildAll`
 
 ## FAQ

--- a/web-extensions/v3/arch-aur/manifest.json
+++ b/web-extensions/v3/arch-aur/manifest.json
@@ -21,6 +21,9 @@
     "gecko": {
         "id": "ArchAur@archlinux.org",
         "strict_min_version": "109.0"
+    },
+    "gecko_android": {
+        "strict_min_version": "121.0"
     }
   },
   "author": "noraj",

--- a/web-extensions/v3/arch-bugs-fs/manifest.json
+++ b/web-extensions/v3/arch-bugs-fs/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchBugsFs@archlinux.org",
         "strict_min_version": "109.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"

--- a/web-extensions/v3/arch-bugs-t/manifest.json
+++ b/web-extensions/v3/arch-bugs-t/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchBugsT@archlinux.org",
         "strict_min_version": "109.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"

--- a/web-extensions/v3/arch-forum-a/manifest.json
+++ b/web-extensions/v3/arch-forum-a/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchForumA@archlinux.org",
         "strict_min_version": "55.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"

--- a/web-extensions/v3/arch-forum-k/manifest.json
+++ b/web-extensions/v3/arch-forum-k/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchForumK@archlinux.org",
         "strict_min_version": "109.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"

--- a/web-extensions/v3/arch-man/manifest.json
+++ b/web-extensions/v3/arch-man/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchMan@archlinux.org",
         "strict_min_version": "109.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"

--- a/web-extensions/v3/arch-pkgs/manifest.json
+++ b/web-extensions/v3/arch-pkgs/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchPkgs@archlinux.org",
         "strict_min_version": "109.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"

--- a/web-extensions/v3/arch-wiki/manifest.json
+++ b/web-extensions/v3/arch-wiki/manifest.json
@@ -21,7 +21,10 @@
     "gecko": {
         "id": "ArchWiki@archlinux.org",
         "strict_min_version": "109.0"
-    }
+    },
+    "gecko_android": {
+      "strict_min_version": "121.0"
+  }
   },
   "author": "noraj",
   "homepage_url": "https://github.com/noraj/firefox-extension-arch-search"


### PR DESCRIPTION
Mozilla has made extensions generally available on Firefox Android after their [2023-12-14 announcement](https://blog.mozilla.org/addons/2023/12/14/a-new-world-of-open-extensions-on-firefox-for-android-has-arrived/).

Even though a mobile browser environment might not be the preferred habitat of most Arch users, I see no good reason against supporting it.

Linter emits `MANIFEST_V3_FIREFOX_ANDROID_LIMITATIONS` warning but none of the [bugs tracked](https://extensionworkshop.com/documentation/develop/developing-extensions-for-firefox-for-android/#mv3-compatibility) affect these extensions.